### PR TITLE
Regression test logs for PR 262

### DIFF
--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Thu Nov  5 05:46:38 MST 2020
+Thu Nov 12 14:23:55 MST 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gfdlmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -50,8 +50,8 @@ Checking test 001 fv3_ccpp_gfdlmp results ....
 Test 001 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -118,8 +118,8 @@ Checking test 002 fv3_ccpp_gfs_v15p2 results ....
 Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -186,8 +186,8 @@ Checking test 003 fv3_ccpp_gfs_v16beta results ....
 Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -254,9 +254,145 @@ Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
 Test 004 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gsd_prod
-Checking test 005 fv3_ccpp_gsd results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 005 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 005 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+Checking test 006 fv3_ccpp_gfs_v16beta_RRTMGP results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 006 fv3_ccpp_gfs_v16beta_RRTMGP PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gsd_prod
+Checking test 007 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -343,12 +479,12 @@ Checking test 005 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 005 fv3_ccpp_gsd PASS
+Test 007 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_thompson_prod
-Checking test 006 fv3_ccpp_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_thompson_prod
+Checking test 008 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -411,12 +547,12 @@ Checking test 006 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_thompson PASS
+Test 008 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_thompson_no_aero_prod
-Checking test 007 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_thompson_no_aero_prod
+Checking test 009 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -479,12 +615,12 @@ Checking test 007 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_thompson_no_aero PASS
+Test 009 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_rrfs_v1beta_prod
-Checking test 008 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_rrfs_v1beta_prod
+Checking test 010 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -547,12 +683,12 @@ Checking test 008 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1beta PASS
+Test 010 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 009 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 011 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -615,12 +751,12 @@ Checking test 009 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 009 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 011 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 010 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -633,18 +769,18 @@ Checking test 010 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 010 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_control_debug_prod
-Checking test 011 fv3_ccpp_control_debug results ....
-Test 011 fv3_ccpp_control_debug PASS
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_control_debug_prod
+Checking test 013 fv3_ccpp_control_debug results ....
+Test 013 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 014 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -707,12 +843,12 @@ Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 012 fv3_ccpp_gfs_v15p2_debug PASS
+Test 014 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_gfs_v16beta_debug_prod
-Checking test 013 fv3_ccpp_gfs_v16beta_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v16beta_debug_prod
+Checking test 015 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -775,12 +911,148 @@ Checking test 013 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 013 fv3_ccpp_gfs_v16beta_debug PASS
+Test 015 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_multigases_prod
-Checking test 014 fv3_ccpp_multigases results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+Checking test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_multigases_prod
+Checking test 018 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -849,12 +1121,12 @@ Checking test 014 fv3_ccpp_multigases results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 014 fv3_ccpp_multigases PASS
+Test 018 fv3_ccpp_multigases PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 015 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -917,12 +1189,12 @@ Checking test 015 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 015 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_27161/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 016 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_24274/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 020 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -935,9 +1207,9 @@ Checking test 016 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 016 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 020 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Nov  5 06:01:43 MST 2020
-Elapsed time: 00h:15m:05s. Have a nice day!
+Thu Nov 12 14:41:06 MST 2020
+Elapsed time: 00h:17m:11s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Thu Nov  5 05:59:04 MST 2020
+Thu Nov 12 15:56:16 MST 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_restart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -274,8 +274,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_read_inc_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_read_inc_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -342,8 +342,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -438,8 +438,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -486,8 +486,8 @@ Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -534,8 +534,8 @@ Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
 Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -582,8 +582,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_stochy_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stochy_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -650,8 +650,8 @@ Checking test 011 fv3_ccpp_stochy results ....
 Test 011 fv3_ccpp_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_iau_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_iau_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -718,8 +718,8 @@ Checking test 012 fv3_ccpp_iau results ....
 Test 012 fv3_ccpp_iau PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_ca_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_ca_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -786,8 +786,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_lheatstrg_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_lheatstrg_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_lheatstrg_prod
 Checking test 014 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -834,8 +834,8 @@ Checking test 014 fv3_ccpp_lheatstrg results ....
 Test 014 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_multigases_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_multigases_prod
 Checking test 015 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -908,8 +908,8 @@ Checking test 015 fv3_ccpp_multigases results ....
 Test 015 fv3_ccpp_multigases PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_control_32bit_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_32bit_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_control_32bit_prod
 Checking test 016 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -976,8 +976,8 @@ Checking test 016 fv3_ccpp_control_32bit results ....
 Test 016 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_stretched_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_stretched_prod
 Checking test 017 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1032,8 +1032,8 @@ Checking test 017 fv3_ccpp_stretched results ....
 Test 017 fv3_ccpp_stretched PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_stretched_nest_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_nest_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_stretched_nest_prod
 Checking test 018 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1099,8 +1099,8 @@ Checking test 018 fv3_ccpp_stretched_nest results ....
 Test 018 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_regional_control_prod
 Checking test 019 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1110,8 +1110,8 @@ Checking test 019 fv3_ccpp_regional_control results ....
 Test 019 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_regional_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_restart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_regional_restart_prod
 Checking test 020 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1119,8 +1119,8 @@ Checking test 020 fv3_ccpp_regional_restart results ....
 Test 020 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_regional_quilt_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_quilt_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_regional_quilt_prod
 Checking test 021 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1130,20 +1130,20 @@ Checking test 021 fv3_ccpp_regional_quilt results ....
 Test 021 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_control_debug_prod
 Checking test 022 fv3_ccpp_control_debug results ....
 Test 022 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_stretched_nest_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_nest_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_stretched_nest_debug_prod
 Checking test 023 fv3_ccpp_stretched_nest_debug results ....
 Test 023 fv3_ccpp_stretched_nest_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfdlmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfdlmp_prod
 Checking test 024 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1190,8 +1190,8 @@ Checking test 024 fv3_ccpp_gfdlmp results ....
 Test 024 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfdlmprad_gwd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1238,8 +1238,8 @@ Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
 Test 025 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfdlmprad_noahmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1286,8 +1286,8 @@ Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
 Test 026 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_csawmg_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_csawmg_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_csawmg_prod
 Checking test 027 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1334,8 +1334,8 @@ Checking test 027 fv3_ccpp_csawmg results ....
 Test 027 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_satmedmf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_satmedmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_satmedmf_prod
 Checking test 028 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1382,8 +1382,8 @@ Checking test 028 fv3_ccpp_satmedmf results ....
 Test 028 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_satmedmfq_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_satmedmfq_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_satmedmfq_prod
 Checking test 029 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1430,8 +1430,8 @@ Checking test 029 fv3_ccpp_satmedmfq results ....
 Test 029 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfdlmp_32bit_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 030 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1478,8 +1478,8 @@ Checking test 030 fv3_ccpp_gfdlmp_32bit results ....
 Test 030 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfdlmprad_32bit_post_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 031 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,8 +1530,8 @@ Checking test 031 fv3_ccpp_gfdlmprad_32bit_post results ....
 Test 031 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_cpt_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_cpt_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_cpt_prod
 Checking test 032 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1584,8 +1584,8 @@ Checking test 032 fv3_ccpp_cpt results ....
 Test 032 fv3_ccpp_cpt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gsd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gsd_prod
 Checking test 033 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1676,8 +1676,8 @@ Checking test 033 fv3_ccpp_gsd results ....
 Test 033 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_thompson_prod
 Checking test 034 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1744,8 +1744,8 @@ Checking test 034 fv3_ccpp_thompson results ....
 Test 034 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_thompson_no_aero_prod
 Checking test 035 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1812,8 +1812,8 @@ Checking test 035 fv3_ccpp_thompson_no_aero results ....
 Test 035 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_rrfs_v1beta_prod
 Checking test 036 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1880,8 +1880,8 @@ Checking test 036 fv3_ccpp_rrfs_v1beta results ....
 Test 036 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v15p2_prod
 Checking test 037 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1948,8 +1948,8 @@ Checking test 037 fv3_ccpp_gfs_v15p2 results ....
 Test 037 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v16beta_prod
 Checking test 038 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2016,9 +2016,145 @@ Checking test 038 fv3_ccpp_gfs_v16beta results ....
 Test 038 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gocart_clm_prod
-Checking test 039 fv3_ccpp_gocart_clm results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 039 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 039 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+Checking test 040 fv3_ccpp_gfs_v16beta_RRTMGP results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 040 fv3_ccpp_gfs_v16beta_RRTMGP PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gocart_clm_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gocart_clm_prod
+Checking test 041 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2061,12 +2197,12 @@ Checking test 039 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 039 fv3_ccpp_gocart_clm PASS
+Test 041 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfs_v16beta_flake_prod
-Checking test 040 fv3_ccpp_gfs_v16beta_flake results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v16beta_flake_prod
+Checking test 042 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2129,12 +2265,12 @@ Checking test 040 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 040 fv3_ccpp_gfs_v16beta_flake PASS
+Test 042 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 041 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 043 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2197,12 +2333,12 @@ Checking test 041 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 041 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 043 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 042 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 044 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2215,12 +2351,12 @@ Checking test 042 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 042 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 044 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gfs_v16beta_debug_prod
-Checking test 043 fv3_ccpp_gfs_v16beta_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v16beta_debug_prod
+Checking test 045 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2283,148 +2419,12 @@ Checking test 043 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 043 fv3_ccpp_gfs_v16beta_debug PASS
+Test 045 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gsd_debug_prod
-Checking test 044 fv3_ccpp_gsd_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gsd_debug PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 045 fv3_ccpp_gsd_diag3d_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gsd_diag3d_debug PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_thompson_debug_prod
-Checking test 046 fv3_ccpp_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2487,12 +2487,12 @@ Checking test 046 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 046 fv3_ccpp_thompson_debug PASS
+Test 046 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 047 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+Checking test 047 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2555,12 +2555,12 @@ Checking test 047 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 047 fv3_ccpp_thompson_no_aero_debug PASS
+Test 047 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 048 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gsd_debug_prod
+Checking test 048 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2623,12 +2623,284 @@ Checking test 048 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 048 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 048 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 049 fv3_ccpp_gsd_diag3d_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 049 fv3_ccpp_gsd_diag3d_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_thompson_debug_prod
+Checking test 050 fv3_ccpp_thompson_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 050 fv3_ccpp_thompson_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 051 fv3_ccpp_thompson_no_aero_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 051 fv3_ccpp_thompson_no_aero_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 052 fv3_ccpp_rrfs_v1beta_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 052 fv3_ccpp_rrfs_v1beta_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2691,12 +2963,12 @@ Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201103/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_7291/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201110/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14590/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2709,9 +2981,9 @@ Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Nov  5 06:29:41 MST 2020
-Elapsed time: 00h:30m:37s. Have a nice day!
+Thu Nov 12 16:27:53 MST 2020
+Elapsed time: 00h:31m:37s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Tue Nov  3 21:08:23 UTC 2020
+Fri Nov 13 02:52:01 UTC 2020
 Start Regression test
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gfdlmp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfdlmp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -50,8 +50,8 @@ Checking test 001 fv3_ccpp_gfdlmp results ....
 Test 001 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -118,8 +118,8 @@ Checking test 002 fv3_ccpp_gfs_v15p2 results ....
 Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -186,8 +186,8 @@ Checking test 003 fv3_ccpp_gfs_v16beta results ....
 Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v16beta_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_flake_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -254,9 +254,145 @@ Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
 Test 004 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gsd_prod
-Checking test 005 fv3_ccpp_gsd results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 005 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 005 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+Checking test 006 fv3_ccpp_gfs_v16beta_RRTMGP results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 006 fv3_ccpp_gfs_v16beta_RRTMGP PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gsd_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gsd_prod
+Checking test 007 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -343,12 +479,12 @@ Checking test 005 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 005 fv3_ccpp_gsd PASS
+Test 007 fv3_ccpp_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_thompson_prod
-Checking test 006 fv3_ccpp_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_thompson_prod
+Checking test 008 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -411,12 +547,12 @@ Checking test 006 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_thompson PASS
+Test 008 fv3_ccpp_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_thompson_no_aero_prod
-Checking test 007 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_thompson_no_aero_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_thompson_no_aero_prod
+Checking test 009 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -479,12 +615,12 @@ Checking test 007 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_thompson_no_aero PASS
+Test 009 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_rrfs_v1beta_prod
-Checking test 008 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_rrfs_v1beta_prod
+Checking test 010 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -547,12 +683,12 @@ Checking test 008 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1beta PASS
+Test 010 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 009 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 011 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -615,12 +751,12 @@ Checking test 009 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 009 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 011 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 010 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -633,18 +769,18 @@ Checking test 010 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 010 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_control_debug_prod
-Checking test 011 fv3_ccpp_control_debug results ....
-Test 011 fv3_ccpp_control_debug PASS
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_control_debug_prod
+Checking test 013 fv3_ccpp_control_debug results ....
+Test 013 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 014 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -707,12 +843,12 @@ Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 012 fv3_ccpp_gfs_v15p2_debug PASS
+Test 014 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_gfs_v16beta_debug_prod
-Checking test 013 fv3_ccpp_gfs_v16beta_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v16beta_debug_prod
+Checking test 015 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -775,12 +911,148 @@ Checking test 013 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 013 fv3_ccpp_gfs_v16beta_debug PASS
+Test 015 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_multigases_prod
-Checking test 014 fv3_ccpp_multigases results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_gfs_v16beta_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+Checking test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/fv3_multigases_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_multigases_prod
+Checking test 018 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -849,12 +1121,12 @@ Checking test 014 fv3_ccpp_multigases results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 014 fv3_ccpp_multigases PASS
+Test 018 fv3_ccpp_multigases PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 015 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -917,12 +1189,12 @@ Checking test 015 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 015 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201103/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_230149/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 016 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_286240/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 020 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -935,9 +1207,9 @@ Checking test 016 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 016 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 020 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Nov  3 21:40:18 UTC 2020
-Elapsed time: 00h:32m:01s. Have a nice day!
+Fri Nov 13 03:24:00 UTC 2020
+Elapsed time: 00h:32m:00s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Sat Nov  7 12:33:43 UTC 2020
+Fri Nov 13 05:02:55 UTC 2020
 Start Regression test
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_control_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_decomp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_2threads_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_restart_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_restart_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -274,8 +274,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_read_inc_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_read_inc_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_read_inc_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -342,8 +342,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -438,8 +438,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -486,8 +486,8 @@ Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -534,8 +534,8 @@ Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
 Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -582,8 +582,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_stochy_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stochy_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -650,8 +650,8 @@ Checking test 011 fv3_ccpp_stochy results ....
 Test 011 fv3_ccpp_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_iau_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_iau_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_iau_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -718,8 +718,8 @@ Checking test 012 fv3_ccpp_iau results ....
 Test 012 fv3_ccpp_iau PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_ca_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_ca_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -786,8 +786,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_lndp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_lndp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_lndp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -854,8 +854,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_lheatstrg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_lheatstrg_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_lheatstrg_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_lheatstrg_prod
 Checking test 015 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -902,8 +902,8 @@ Checking test 015 fv3_ccpp_lheatstrg results ....
 Test 015 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmprad_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmprad_prod
 Checking test 016 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,8 +951,8 @@ Checking test 016 fv3_ccpp_gfdlmprad results ....
 Test 016 fv3_ccpp_gfdlmprad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmprad_atmwav_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_atmwav_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 017 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1000,8 +1000,8 @@ Checking test 017 fv3_ccpp_gfdlmprad_atmwav results ....
 Test 017 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_wrtGauss_nemsio_c768_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 018 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1049,8 +1049,8 @@ Checking test 018 fv3_ccpp_wrtGauss_nemsio_c768 results ....
 Test 018 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_multigases_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_multigases_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_multigases_prod
 Checking test 019 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1123,8 +1123,8 @@ Checking test 019 fv3_ccpp_multigases results ....
 Test 019 fv3_ccpp_multigases PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_control_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_control_32bit_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_32bit_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_control_32bit_prod
 Checking test 020 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1191,8 +1191,8 @@ Checking test 020 fv3_ccpp_control_32bit results ....
 Test 020 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_stretched_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_stretched_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_stretched_prod
 Checking test 021 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1247,8 +1247,8 @@ Checking test 021 fv3_ccpp_stretched results ....
 Test 021 fv3_ccpp_stretched PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_stretched_nest_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_nest_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_stretched_nest_prod
 Checking test 022 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1314,8 +1314,8 @@ Checking test 022 fv3_ccpp_stretched_nest results ....
 Test 022 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_regional_control_prod
 Checking test 023 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1325,8 +1325,8 @@ Checking test 023 fv3_ccpp_regional_control results ....
 Test 023 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_regional_restart_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_restart_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_regional_restart_prod
 Checking test 024 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1334,8 +1334,8 @@ Checking test 024 fv3_ccpp_regional_restart results ....
 Test 024 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_regional_quilt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_regional_quilt_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_quilt_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_regional_quilt_prod
 Checking test 025 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1345,8 +1345,8 @@ Checking test 025 fv3_ccpp_regional_quilt results ....
 Test 025 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_regional_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_regional_c768_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_c768_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_regional_c768_prod
 Checking test 026 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1356,20 +1356,20 @@ Checking test 026 fv3_ccpp_regional_c768 results ....
 Test 026 fv3_ccpp_regional_c768 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_control_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_control_debug_prod
 Checking test 027 fv3_ccpp_control_debug results ....
 Test 027 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_stretched_nest_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_nest_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_stretched_nest_debug_prod
 Checking test 028 fv3_ccpp_stretched_nest_debug results ....
 Test 028 fv3_ccpp_stretched_nest_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmp_prod
 Checking test 029 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1416,8 +1416,8 @@ Checking test 029 fv3_ccpp_gfdlmp results ....
 Test 029 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmprad_gwd_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 030 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1464,8 +1464,8 @@ Checking test 030 fv3_ccpp_gfdlmprad_gwd results ....
 Test 030 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmprad_noahmp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 031 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1512,8 +1512,8 @@ Checking test 031 fv3_ccpp_gfdlmprad_noahmp results ....
 Test 031 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_csawmg_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_csawmg_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_csawmg_prod
 Checking test 032 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1560,8 +1560,8 @@ Checking test 032 fv3_ccpp_csawmg results ....
 Test 032 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_satmedmf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_satmedmf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_satmedmf_prod
 Checking test 033 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1608,8 +1608,8 @@ Checking test 033 fv3_ccpp_satmedmf results ....
 Test 033 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_satmedmfq_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_satmedmfq_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_satmedmfq_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_satmedmfq_prod
 Checking test 034 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1656,8 +1656,8 @@ Checking test 034 fv3_ccpp_satmedmfq results ....
 Test 034 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmp_32bit_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 035 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1704,8 +1704,8 @@ Checking test 035 fv3_ccpp_gfdlmp_32bit results ....
 Test 035 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfdlmprad_32bit_post_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 036 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1756,8 +1756,8 @@ Checking test 036 fv3_ccpp_gfdlmprad_32bit_post results ....
 Test 036 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_cpt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_cpt_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_cpt_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_cpt_prod
 Checking test 037 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1810,8 +1810,8 @@ Checking test 037 fv3_ccpp_cpt results ....
 Test 037 fv3_ccpp_cpt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gsd_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gsd_prod
 Checking test 038 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1902,8 +1902,8 @@ Checking test 038 fv3_ccpp_gsd results ....
 Test 038 fv3_ccpp_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_rap_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_rap_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rap_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_rap_prod
 Checking test 039 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1970,8 +1970,8 @@ Checking test 039 fv3_ccpp_rap results ....
 Test 039 fv3_ccpp_rap PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_hrrr_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_hrrr_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_hrrr_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_hrrr_prod
 Checking test 040 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2038,8 +2038,8 @@ Checking test 040 fv3_ccpp_hrrr results ....
 Test 040 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_thompson_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_thompson_prod
 Checking test 041 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2106,8 +2106,8 @@ Checking test 041 fv3_ccpp_thompson results ....
 Test 041 fv3_ccpp_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_thompson_no_aero_prod
 Checking test 042 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2174,8 +2174,8 @@ Checking test 042 fv3_ccpp_thompson_no_aero results ....
 Test 042 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_rrfs_v1beta_prod
 Checking test 043 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2242,8 +2242,8 @@ Checking test 043 fv3_ccpp_rrfs_v1beta results ....
 Test 043 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v15p2_prod
 Checking test 044 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2310,8 +2310,8 @@ Checking test 044 fv3_ccpp_gfs_v15p2 results ....
 Test 044 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v16beta_prod
 Checking test 045 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2378,153 +2378,9 @@ Checking test 045 fv3_ccpp_gfs_v16beta results ....
 Test 045 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 046 fv3_ccpp_gfsv16_csawmg results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nemsio .........OK
- Comparing phyf024.nemsio .........OK
- Comparing dynf000.nemsio .........OK
- Comparing dynf024.nemsio .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfsv16_csawmg PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 047 fv3_ccpp_gfsv16_csawmgt results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nemsio .........OK
- Comparing phyf024.nemsio .........OK
- Comparing dynf000.nemsio .........OK
- Comparing dynf024.nemsio .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfsv16_csawmgt PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gocart_clm_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gocart_clm_prod
-Checking test 048 fv3_ccpp_gocart_clm results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nemsio .........OK
- Comparing phyf024.nemsio .........OK
- Comparing dynf000.nemsio .........OK
- Comparing dynf024.nemsio .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gocart_clm PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfs_v16beta_flake_prod
-Checking test 049 fv3_ccpp_gfs_v16beta_flake results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2587,12 +2443,12 @@ Checking test 049 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfs_v16beta_flake PASS
+Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 050 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+Checking test 047 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2655,12 +2511,292 @@ Checking test 050 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 047 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfsv16_csawmg_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 048 fv3_ccpp_gfsv16_csawmg results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.nemsio .........OK
+ Comparing phyf024.nemsio .........OK
+ Comparing dynf000.nemsio .........OK
+ Comparing dynf024.nemsio .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 048 fv3_ccpp_gfsv16_csawmg PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfsv16_csawmgt_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 049 fv3_ccpp_gfsv16_csawmgt results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.nemsio .........OK
+ Comparing phyf024.nemsio .........OK
+ Comparing dynf000.nemsio .........OK
+ Comparing dynf024.nemsio .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 049 fv3_ccpp_gfsv16_csawmgt PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gocart_clm_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gocart_clm_prod
+Checking test 050 fv3_ccpp_gocart_clm results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.nemsio .........OK
+ Comparing phyf024.nemsio .........OK
+ Comparing dynf000.nemsio .........OK
+ Comparing dynf024.nemsio .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 050 fv3_ccpp_gocart_clm PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_flake_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v16beta_flake_prod
+Checking test 051 fv3_ccpp_gfs_v16beta_flake results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 051 fv3_ccpp_gfs_v16beta_flake PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 052 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 052 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2673,12 +2809,12 @@ Checking test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 052 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 054 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2741,12 +2877,12 @@ Checking test 052 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfs_v15p2_debug PASS
+Test 054 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gfs_v16beta_debug_prod
-Checking test 053 fv3_ccpp_gfs_v16beta_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v16beta_debug_prod
+Checking test 055 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2809,148 +2945,12 @@ Checking test 053 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v16beta_debug PASS
+Test 055 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gsd_debug_prod
-Checking test 054 fv3_ccpp_gsd_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gsd_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 055 fv3_ccpp_gsd_diag3d_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gsd_diag3d_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_thompson_debug_prod
-Checking test 056 fv3_ccpp_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 056 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3013,12 +3013,12 @@ Checking test 056 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 056 fv3_ccpp_thompson_debug PASS
+Test 056 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 057 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+Checking test 057 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3081,12 +3081,12 @@ Checking test 057 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_thompson_no_aero_debug PASS
+Test 057 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 058 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gsd_debug_prod
+Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3149,12 +3149,284 @@ Checking test 058 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 058 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 059 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 059 fv3_ccpp_gsd_diag3d_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_thompson_debug_prod
+Checking test 060 fv3_ccpp_thompson_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 060 fv3_ccpp_thompson_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 061 fv3_ccpp_thompson_no_aero_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3217,12 +3489,12 @@ Checking test 059 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 059 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 060 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3235,12 +3507,12 @@ Checking test 060 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 060 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_control_prod
-Checking test 061 cpld_control results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_control_prod
+Checking test 065 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3287,12 +3559,12 @@ Checking test 061 cpld_control results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 061 cpld_control PASS
+Test 065 cpld_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_2threads_prod
-Checking test 062 cpld_2threads results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_2threads_prod
+Checking test 066 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3339,12 +3611,12 @@ Checking test 062 cpld_2threads results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 062 cpld_2threads PASS
+Test 066 cpld_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_decomp_prod
-Checking test 063 cpld_decomp results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_decomp_prod
+Checking test 067 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3391,12 +3663,12 @@ Checking test 063 cpld_decomp results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 063 cpld_decomp PASS
+Test 067 cpld_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_satmedmf_prod
-Checking test 064 cpld_satmedmf results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_satmedmf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_satmedmf_prod
+Checking test 068 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3443,12 +3715,12 @@ Checking test 064 cpld_satmedmf results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 064 cpld_satmedmf PASS
+Test 068 cpld_satmedmf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_ca_prod
-Checking test 065 cpld_ca results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_ca_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_ca_prod
+Checking test 069 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3495,12 +3767,12 @@ Checking test 065 cpld_ca results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 065 cpld_ca PASS
+Test 069 cpld_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_mx025_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_control_mx025_prod
-Checking test 066 cpld_control_mx025 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_mx025_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_control_mx025_prod
+Checking test 070 cpld_control_mx025 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3550,12 +3822,12 @@ Checking test 066 cpld_control_mx025 results ....
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 066 cpld_control_mx025 PASS
+Test 070 cpld_control_mx025 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_mx025_12h_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_control_mx025_12h_prod
-Checking test 067 cpld_control_mx025_12h results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_mx025_12h_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_control_mx025_12h_prod
+Checking test 071 cpld_control_mx025_12h results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -3605,12 +3877,12 @@ Checking test 067 cpld_control_mx025_12h results ....
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
-Test 067 cpld_control_mx025_12h PASS
+Test 071 cpld_control_mx025_12h PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_mx025_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_restart_mx025_prod
-Checking test 068 cpld_restart_mx025 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_mx025_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_restart_mx025_prod
+Checking test 072 cpld_restart_mx025 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3660,12 +3932,12 @@ Checking test 068 cpld_restart_mx025 results ....
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 068 cpld_restart_mx025 PASS
+Test 072 cpld_restart_mx025 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_control_c192_prod
-Checking test 069 cpld_control_c192 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_control_c192_prod
+Checking test 073 cpld_control_c192 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3712,67 +3984,12 @@ Checking test 069 cpld_control_c192 results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 069 cpld_control_c192 PASS
+Test 073 cpld_control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_control_c384_prod
-Checking test 070 cpld_control_c384 results ....
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 070 cpld_control_c384 PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_controlfrac_c384_prod
-Checking test 071 cpld_controlfrac_c384 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_c384_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_control_c384_prod
+Checking test 074 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3822,12 +4039,67 @@ Checking test 071 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
-Test 071 cpld_controlfrac_c384 PASS
+Test 074 cpld_control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_bmark_prod
-Checking test 072 cpld_bmark results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_controlfrac_c384_prod
+Checking test 075 cpld_controlfrac_c384 results ....
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2016-10-04-00000.nc .........OK
+Test 075 cpld_controlfrac_c384 PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_bmark_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_bmark_prod
+Checking test 076 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3877,12 +4149,12 @@ Checking test 072 cpld_bmark results ....
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
-Test 072 cpld_bmark PASS
+Test 076 cpld_bmark PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_bmark_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_bmark_wave_prod
-Checking test 073 cpld_bmark_wave results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_bmark_wave_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_bmark_wave_prod
+Checking test 077 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3935,12 +4207,12 @@ Checking test 073 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
-Test 073 cpld_bmark_wave PASS
+Test 077 cpld_bmark_wave PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/cpld_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/cpld_debug_prod
-Checking test 074 cpld_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/cpld_debug_prod
+Checking test 078 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -3987,51 +4259,51 @@ Checking test 074 cpld_debug results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
-Test 074 cpld_debug PASS
+Test 078 cpld_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/datm_control_cfsr_prod
-Checking test 075 datm_control_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/datm_control_cfsr_prod
+Checking test 079 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 075 datm_control_cfsr PASS
+Test 079 datm_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/datm_control_gefs_prod
-Checking test 076 datm_control_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/datm_control_gefs_prod
+Checking test 080 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 076 datm_control_gefs PASS
+Test 080 datm_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/datm_mx025_cfsr_prod
-Checking test 077 datm_mx025_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/datm_mx025_cfsr_prod
+Checking test 081 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 077 datm_mx025_cfsr PASS
+Test 081 datm_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_140399/datm_mx025_gefs_prod
-Checking test 078 datm_mx025_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_242618/datm_mx025_gefs_prod
+Checking test 082 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 078 datm_mx025_gefs PASS
+Test 082 datm_mx025_gefs PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Nov  7 14:01:06 UTC 2020
-Elapsed time: 01h:27m:29s. Have a nice day!
+Fri Nov 13 07:36:04 UTC 2020
+Elapsed time: 02h:33m:11s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Wed Nov 11 14:15:03 CST 2020
+Thu Nov 12 16:45:13 CST 2020
 Start Regression test
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_restart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_read_inc_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_read_inc_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stochy_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_stochy_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -651,7 +651,7 @@ Test 011 fv3_ccpp_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_iau_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_iau_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -719,7 +719,7 @@ Test 012 fv3_ccpp_iau PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_ca_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -787,7 +787,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmprad_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmprad_prod
 Checking test 014 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -836,7 +836,7 @@ Test 014 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 015 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 016 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -934,7 +934,7 @@ Test 016 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_multigases_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_multigases_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1008,7 +1008,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_control_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1076,7 +1076,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_stretched_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1132,7 +1132,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_stretched_nest_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1199,7 +1199,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_regional_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1210,7 +1210,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_restart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_regional_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1219,7 +1219,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_quilt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_regional_quilt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1230,7 +1230,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_regional_c768_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_regional_c768_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_regional_c768_prod
 Checking test 024 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1241,19 +1241,19 @@ Test 024 fv3_ccpp_regional_c768 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_control_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
 Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
 Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1301,7 +1301,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1349,7 +1349,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1397,7 +1397,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1445,7 +1445,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_satmedmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1493,7 +1493,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1541,7 +1541,7 @@ Test 032 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1593,7 +1593,7 @@ Test 033 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_cpt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_cpt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_cpt_prod
 Checking test 034 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1647,7 +1647,7 @@ Test 034 fv3_ccpp_cpt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gsd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gsd_prod
 Checking test 035 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1739,7 +1739,7 @@ Test 035 fv3_ccpp_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_thompson_prod
 Checking test 036 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1807,7 +1807,7 @@ Test 036 fv3_ccpp_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_thompson_no_aero_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_thompson_no_aero_prod
 Checking test 037 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1875,7 +1875,7 @@ Test 037 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_rrfs_v1beta_prod
 Checking test 038 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1943,7 +1943,7 @@ Test 038 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v15p2_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v15p2_prod
 Checking test 039 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2011,7 +2011,7 @@ Test 039 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v16beta_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v16beta_prod
 Checking test 040 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2079,7 +2079,7 @@ Test 040 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 041 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2147,7 +2147,7 @@ Test 041 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 042 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2215,7 +2215,7 @@ Test 042 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 043 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2263,7 +2263,7 @@ Test 043 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 044 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2311,7 +2311,7 @@ Test 044 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gocart_clm_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gocart_clm_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gocart_clm_prod
 Checking test 045 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2359,7 +2359,7 @@ Test 045 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 046 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2427,7 +2427,7 @@ Test 046 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2495,7 +2495,7 @@ Test 047 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2513,7 +2513,7 @@ Test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 049 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2581,7 +2581,7 @@ Test 049 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 050 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2649,7 +2649,7 @@ Test 050 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 051 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2717,7 +2717,7 @@ Test 051 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 052 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2785,7 +2785,7 @@ Test 052 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gsd_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gsd_debug_prod
 Checking test 053 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2853,7 +2853,7 @@ Test 053 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 054 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2921,7 +2921,7 @@ Test 054 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_thompson_debug_prod
 Checking test 055 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2989,7 +2989,7 @@ Test 055 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 056 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3057,7 +3057,7 @@ Test 056 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 057 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3125,7 +3125,7 @@ Test 057 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 058 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3193,7 +3193,7 @@ Test 058 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 059 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3211,7 +3211,7 @@ Test 059 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_control_prod
 Checking test 060 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3263,7 +3263,7 @@ Test 060 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_2threads_prod
 Checking test 061 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3315,7 +3315,7 @@ Test 061 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_decomp_prod
 Checking test 062 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3367,7 +3367,7 @@ Test 062 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_satmedmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_satmedmf_prod
 Checking test 063 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3419,7 +3419,7 @@ Test 063 cpld_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_ca_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_ca_prod
 Checking test 064 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3471,7 +3471,7 @@ Test 064 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_mx025_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_control_mx025_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_control_mx025_prod
 Checking test 065 cpld_control_mx025 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3526,7 +3526,7 @@ Test 065 cpld_control_mx025 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_mx025_12h_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_control_mx025_12h_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_control_mx025_12h_prod
 Checking test 066 cpld_control_mx025_12h results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -3581,7 +3581,7 @@ Test 066 cpld_control_mx025_12h PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_mx025_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_restart_mx025_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_restart_mx025_prod
 Checking test 067 cpld_restart_mx025 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3636,7 +3636,7 @@ Test 067 cpld_restart_mx025 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_control_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_control_c192_prod
 Checking test 068 cpld_control_c192 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3688,7 +3688,7 @@ Test 068 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_control_c384_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_control_c384_prod
 Checking test 069 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3743,7 +3743,7 @@ Test 069 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_controlfrac_c384_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_controlfrac_c384_prod
 Checking test 070 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3798,7 +3798,7 @@ Test 070 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_bmark_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_bmark_prod
 Checking test 071 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3853,7 +3853,7 @@ Test 071 cpld_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_bmark_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_bmark_wave_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_bmark_wave_prod
 Checking test 072 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3911,7 +3911,7 @@ Test 072 cpld_bmark_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/cpld_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/cpld_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/cpld_debug_prod
 Checking test 073 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -3963,7 +3963,7 @@ Test 073 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/datm_control_cfsr_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/datm_control_cfsr_prod
 Checking test 074 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -3972,7 +3972,7 @@ Test 074 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/datm_control_gefs_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/datm_control_gefs_prod
 Checking test 075 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -3981,7 +3981,7 @@ Test 075 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/datm_mx025_cfsr_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/datm_mx025_cfsr_prod
 Checking test 076 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3993,7 +3993,7 @@ Test 076 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_133940/datm_mx025_gefs_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_102330/datm_mx025_gefs_prod
 Checking test 077 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4005,5 +4005,5 @@ Test 077 datm_mx025_gefs PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Nov 11 15:23:17 CST 2020
-Elapsed time: 01h:08m:15s. Have a nice day!
+Thu Nov 12 17:48:19 CST 2020
+Elapsed time: 01h:03m:08s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,9 +1,9 @@
-Fri Nov  6 17:12:05 UTC 2020
+Thu Nov 12 21:01:25 UTC 2020
 Start Regression test
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_control_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_decomp_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_2threads_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_restart_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_restart_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -274,8 +274,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_read_inc_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_read_inc_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_read_inc_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -342,8 +342,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_netcdf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -438,8 +438,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -486,8 +486,8 @@ Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_nemsio_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -534,8 +534,8 @@ Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
 Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -582,8 +582,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_stochy_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stochy_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -650,8 +650,8 @@ Checking test 011 fv3_ccpp_stochy results ....
 Test 011 fv3_ccpp_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_iau_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_iau_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_iau_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -718,8 +718,8 @@ Checking test 012 fv3_ccpp_iau results ....
 Test 012 fv3_ccpp_iau PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_lheatstrg_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_lheatstrg_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_lheatstrg_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_lheatstrg_prod
 Checking test 013 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -766,8 +766,8 @@ Checking test 013 fv3_ccpp_lheatstrg results ....
 Test 013 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_multigases_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_multigases_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_multigases_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_multigases_prod
 Checking test 014 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -840,8 +840,8 @@ Checking test 014 fv3_ccpp_multigases results ....
 Test 014 fv3_ccpp_multigases PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_control_32bit_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_32bit_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_control_32bit_prod
 Checking test 015 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -908,8 +908,8 @@ Checking test 015 fv3_ccpp_control_32bit results ....
 Test 015 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stretched_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_stretched_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stretched_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_stretched_prod
 Checking test 016 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -964,8 +964,8 @@ Checking test 016 fv3_ccpp_stretched results ....
 Test 016 fv3_ccpp_stretched PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_stretched_nest_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stretched_nest_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_stretched_nest_prod
 Checking test 017 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,8 +1031,8 @@ Checking test 017 fv3_ccpp_stretched_nest results ....
 Test 017 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_regional_control_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_regional_control_prod
 Checking test 018 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1042,8 +1042,8 @@ Checking test 018 fv3_ccpp_regional_control results ....
 Test 018 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_regional_restart_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_restart_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_regional_restart_prod
 Checking test 019 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1051,8 +1051,8 @@ Checking test 019 fv3_ccpp_regional_restart results ....
 Test 019 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_quilt_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_regional_quilt_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_quilt_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_regional_quilt_prod
 Checking test 020 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1062,20 +1062,20 @@ Checking test 020 fv3_ccpp_regional_quilt results ....
 Test 020 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_control_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_control_debug_prod
 Checking test 021 fv3_ccpp_control_debug results ....
 Test 021 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_stretched_nest_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stretched_nest_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_stretched_nest_debug_prod
 Checking test 022 fv3_ccpp_stretched_nest_debug results ....
 Test 022 fv3_ccpp_stretched_nest_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmp_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfdlmp_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmp_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfdlmp_prod
 Checking test 023 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1122,8 +1122,8 @@ Checking test 023 fv3_ccpp_gfdlmp results ....
 Test 023 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfdlmprad_gwd_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_gwd_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 024 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1170,8 +1170,8 @@ Checking test 024 fv3_ccpp_gfdlmprad_gwd results ....
 Test 024 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfdlmprad_noahmp_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 025 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1218,8 +1218,8 @@ Checking test 025 fv3_ccpp_gfdlmprad_noahmp results ....
 Test 025 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_csawmg_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_csawmg_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_csawmg_prod
 Checking test 026 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1266,8 +1266,8 @@ Checking test 026 fv3_ccpp_csawmg results ....
 Test 026 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_satmedmf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_satmedmf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_satmedmf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_satmedmf_prod
 Checking test 027 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1314,8 +1314,8 @@ Checking test 027 fv3_ccpp_satmedmf results ....
 Test 027 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_satmedmfq_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_satmedmfq_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_satmedmfq_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_satmedmfq_prod
 Checking test 028 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1362,8 +1362,8 @@ Checking test 028 fv3_ccpp_satmedmfq results ....
 Test 028 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfdlmp_32bit_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmp_32bit_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 029 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1410,8 +1410,8 @@ Checking test 029 fv3_ccpp_gfdlmp_32bit results ....
 Test 029 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfdlmprad_32bit_post_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 030 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1462,8 +1462,8 @@ Checking test 030 fv3_ccpp_gfdlmprad_32bit_post results ....
 Test 030 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_cpt_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_cpt_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_cpt_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_cpt_prod
 Checking test 031 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1516,8 +1516,8 @@ Checking test 031 fv3_ccpp_cpt results ....
 Test 031 fv3_ccpp_cpt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gsd_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gsd_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gsd_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gsd_prod
 Checking test 032 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1608,8 +1608,8 @@ Checking test 032 fv3_ccpp_gsd results ....
 Test 032 fv3_ccpp_gsd PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_thompson_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_thompson_prod
 Checking test 033 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1676,8 +1676,8 @@ Checking test 033 fv3_ccpp_thompson results ....
 Test 033 fv3_ccpp_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_no_aero_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_thompson_no_aero_prod
 Checking test 034 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1744,8 +1744,8 @@ Checking test 034 fv3_ccpp_thompson_no_aero results ....
 Test 034 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_rrfs_v1beta_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_rrfs_v1beta_prod
 Checking test 035 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1812,8 +1812,8 @@ Checking test 035 fv3_ccpp_rrfs_v1beta results ....
 Test 035 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfsv16_csawmg_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfsv16_csawmg_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 036 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1860,8 +1860,8 @@ Checking test 036 fv3_ccpp_gfsv16_csawmg results ....
 Test 036 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfsv16_csawmgt_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfsv16_csawmgt_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 037 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1908,8 +1908,8 @@ Checking test 037 fv3_ccpp_gfsv16_csawmgt results ....
 Test 037 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gocart_clm_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gocart_clm_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gocart_clm_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gocart_clm_prod
 Checking test 038 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1956,8 +1956,8 @@ Checking test 038 fv3_ccpp_gocart_clm results ....
 Test 038 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfs_v16beta_flake_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfs_v16beta_flake_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 039 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2024,8 +2024,8 @@ Checking test 039 fv3_ccpp_gfs_v16beta_flake results ....
 Test 039 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 040 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2092,8 +2092,8 @@ Checking test 040 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
 Test 040 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 041 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2110,8 +2110,8 @@ Checking test 041 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
 Test 041 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gsd_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gsd_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gsd_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gsd_debug_prod
 Checking test 042 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2178,8 +2178,8 @@ Checking test 042 fv3_ccpp_gsd_debug results ....
 Test 042 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_gsd_diag3d_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gsd_diag3d_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 043 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2246,8 +2246,8 @@ Checking test 043 fv3_ccpp_gsd_diag3d_debug results ....
 Test 043 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_thompson_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_thompson_debug_prod
 Checking test 044 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2314,8 +2314,8 @@ Checking test 044 fv3_ccpp_thompson_debug results ....
 Test 044 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_thompson_no_aero_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_no_aero_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 045 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2382,8 +2382,8 @@ Checking test 045 fv3_ccpp_thompson_no_aero_debug results ....
 Test 045 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_rrfs_v1beta_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 046 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2450,8 +2450,8 @@ Checking test 046 fv3_ccpp_rrfs_v1beta_debug results ....
 Test 046 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2518,8 +2518,8 @@ Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
 Test 047 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_9428/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_10341/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2537,5 +2537,5 @@ Test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Nov  6 17:46:41 UTC 2020
-Elapsed time: 00h:34m:37s. Have a nice day!
+Thu Nov 12 21:49:46 UTC 2020
+Elapsed time: 00h:48m:23s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,9 +1,9 @@
-Sat Nov  7 12:44:50 UTC 2020
+Thu Nov 12 21:25:12 UTC 2020
 Start Regression test
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_control_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_decomp_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_2threads_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_restart_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_restart_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -274,8 +274,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_read_inc_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_read_inc_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_read_inc_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -342,8 +342,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_netcdf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -438,8 +438,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -486,8 +486,8 @@ Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_nemsio_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -534,8 +534,8 @@ Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
 Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -582,8 +582,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_stochy_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stochy_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -650,8 +650,8 @@ Checking test 011 fv3_ccpp_stochy results ....
 Test 011 fv3_ccpp_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_iau_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_iau_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_iau_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -718,8 +718,8 @@ Checking test 012 fv3_ccpp_iau results ....
 Test 012 fv3_ccpp_iau PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_lheatstrg_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_lheatstrg_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_lheatstrg_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_lheatstrg_prod
 Checking test 013 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -766,8 +766,8 @@ Checking test 013 fv3_ccpp_lheatstrg results ....
 Test 013 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmprad_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmprad_prod
 Checking test 014 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -815,8 +815,8 @@ Checking test 014 fv3_ccpp_gfdlmprad results ....
 Test 014 fv3_ccpp_gfdlmprad PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmprad_atmwav_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_atmwav_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 015 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -864,8 +864,8 @@ Checking test 015 fv3_ccpp_gfdlmprad_atmwav results ....
 Test 015 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_multigases_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_multigases_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_multigases_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_multigases_prod
 Checking test 016 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -938,8 +938,8 @@ Checking test 016 fv3_ccpp_multigases results ....
 Test 016 fv3_ccpp_multigases PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_control_32bit_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_32bit_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_control_32bit_prod
 Checking test 017 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1006,8 +1006,8 @@ Checking test 017 fv3_ccpp_control_32bit results ....
 Test 017 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stretched_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_stretched_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stretched_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_stretched_prod
 Checking test 018 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1062,8 +1062,8 @@ Checking test 018 fv3_ccpp_stretched results ....
 Test 018 fv3_ccpp_stretched PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_stretched_nest_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stretched_nest_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_stretched_nest_prod
 Checking test 019 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1129,8 +1129,8 @@ Checking test 019 fv3_ccpp_stretched_nest results ....
 Test 019 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_regional_control_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_regional_control_prod
 Checking test 020 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1140,8 +1140,8 @@ Checking test 020 fv3_ccpp_regional_control results ....
 Test 020 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_regional_restart_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_restart_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_regional_restart_prod
 Checking test 021 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1149,8 +1149,8 @@ Checking test 021 fv3_ccpp_regional_restart results ....
 Test 021 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_quilt_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_regional_quilt_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_quilt_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_regional_quilt_prod
 Checking test 022 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1160,8 +1160,8 @@ Checking test 022 fv3_ccpp_regional_quilt results ....
 Test 022 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_regional_c768_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_regional_c768_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_regional_c768_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_regional_c768_prod
 Checking test 023 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1171,20 +1171,20 @@ Checking test 023 fv3_ccpp_regional_c768 results ....
 Test 023 fv3_ccpp_regional_c768 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_control_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_control_debug_prod
 Checking test 024 fv3_ccpp_control_debug results ....
 Test 024 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_stretched_nest_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_stretched_nest_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_stretched_nest_debug_prod
 Checking test 025 fv3_ccpp_stretched_nest_debug results ....
 Test 025 fv3_ccpp_stretched_nest_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmp_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmp_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmp_prod
 Checking test 026 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1231,8 +1231,8 @@ Checking test 026 fv3_ccpp_gfdlmp results ....
 Test 026 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmprad_gwd_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_gwd_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 027 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1279,8 +1279,8 @@ Checking test 027 fv3_ccpp_gfdlmprad_gwd results ....
 Test 027 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmprad_noahmp_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 028 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1327,8 +1327,8 @@ Checking test 028 fv3_ccpp_gfdlmprad_noahmp results ....
 Test 028 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_csawmg_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_csawmg_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_csawmg_prod
 Checking test 029 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1375,8 +1375,8 @@ Checking test 029 fv3_ccpp_csawmg results ....
 Test 029 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_satmedmf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_satmedmf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_satmedmf_prod
 Checking test 030 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1423,8 +1423,8 @@ Checking test 030 fv3_ccpp_satmedmf results ....
 Test 030 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_satmedmfq_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_satmedmfq_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_satmedmfq_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_satmedmfq_prod
 Checking test 031 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1471,8 +1471,8 @@ Checking test 031 fv3_ccpp_satmedmfq results ....
 Test 031 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmp_32bit_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmp_32bit_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1519,8 +1519,8 @@ Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
 Test 032 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfdlmprad_32bit_post_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1571,8 +1571,8 @@ Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
 Test 033 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_cpt_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_cpt_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_cpt_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_cpt_prod
 Checking test 034 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1625,8 +1625,8 @@ Checking test 034 fv3_ccpp_cpt results ....
 Test 034 fv3_ccpp_cpt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gsd_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gsd_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gsd_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gsd_prod
 Checking test 035 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1717,8 +1717,8 @@ Checking test 035 fv3_ccpp_gsd results ....
 Test 035 fv3_ccpp_gsd PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_thompson_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_thompson_prod
 Checking test 036 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1785,8 +1785,8 @@ Checking test 036 fv3_ccpp_thompson results ....
 Test 036 fv3_ccpp_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_no_aero_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_thompson_no_aero_prod
 Checking test 037 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1853,8 +1853,8 @@ Checking test 037 fv3_ccpp_thompson_no_aero results ....
 Test 037 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_rrfs_v1beta_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_rrfs_v1beta_prod
 Checking test 038 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1921,8 +1921,8 @@ Checking test 038 fv3_ccpp_rrfs_v1beta results ....
 Test 038 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfsv16_csawmg_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfsv16_csawmg_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 039 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1969,8 +1969,8 @@ Checking test 039 fv3_ccpp_gfsv16_csawmg results ....
 Test 039 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfsv16_csawmgt_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfsv16_csawmgt_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 040 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2017,8 +2017,8 @@ Checking test 040 fv3_ccpp_gfsv16_csawmgt results ....
 Test 040 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gocart_clm_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gocart_clm_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gocart_clm_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gocart_clm_prod
 Checking test 041 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2065,8 +2065,8 @@ Checking test 041 fv3_ccpp_gocart_clm results ....
 Test 041 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gfs_v16beta_flake_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gfs_v16beta_flake_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 042 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2133,8 +2133,8 @@ Checking test 042 fv3_ccpp_gfs_v16beta_flake results ....
 Test 042 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 043 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2201,8 +2201,8 @@ Checking test 043 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
 Test 043 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 044 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2219,8 +2219,8 @@ Checking test 044 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
 Test 044 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gsd_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gsd_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gsd_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gsd_debug_prod
 Checking test 045 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2287,8 +2287,8 @@ Checking test 045 fv3_ccpp_gsd_debug results ....
 Test 045 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_gsd_diag3d_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_gsd_diag3d_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 046 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2355,8 +2355,8 @@ Checking test 046 fv3_ccpp_gsd_diag3d_debug results ....
 Test 046 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_thompson_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_thompson_debug_prod
 Checking test 047 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2423,8 +2423,8 @@ Checking test 047 fv3_ccpp_thompson_debug results ....
 Test 047 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_thompson_no_aero_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_thompson_no_aero_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 048 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2491,8 +2491,8 @@ Checking test 048 fv3_ccpp_thompson_no_aero_debug results ....
 Test 048 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_rrfs_v1beta_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 049 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2559,8 +2559,8 @@ Checking test 049 fv3_ccpp_rrfs_v1beta_debug results ....
 Test 049 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 050 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2627,8 +2627,8 @@ Checking test 050 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
 Test 050 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2645,8 +2645,8 @@ Checking test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
 Test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_control_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_control_prod
 Checking test 052 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -2697,8 +2697,8 @@ Checking test 052 cpld_control results ....
 Test 052 cpld_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_2threads_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_2threads_prod
 Checking test 053 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -2749,8 +2749,8 @@ Checking test 053 cpld_2threads results ....
 Test 053 cpld_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_decomp_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_decomp_prod
 Checking test 054 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -2801,8 +2801,8 @@ Checking test 054 cpld_decomp results ....
 Test 054 cpld_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_satmedmf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_satmedmf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_satmedmf_prod
 Checking test 055 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -2853,8 +2853,8 @@ Checking test 055 cpld_satmedmf results ....
 Test 055 cpld_satmedmf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_ca_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_ca_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_ca_prod
 Checking test 056 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -2905,8 +2905,8 @@ Checking test 056 cpld_ca results ....
 Test 056 cpld_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_mx025_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_control_mx025_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_mx025_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_control_mx025_prod
 Checking test 057 cpld_control_mx025 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -2960,8 +2960,8 @@ Checking test 057 cpld_control_mx025 results ....
 Test 057 cpld_control_mx025 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_mx025_12h_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_control_mx025_12h_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_mx025_12h_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_control_mx025_12h_prod
 Checking test 058 cpld_control_mx025_12h results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -3015,8 +3015,8 @@ Checking test 058 cpld_control_mx025_12h results ....
 Test 058 cpld_control_mx025_12h PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_mx025_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_restart_mx025_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_mx025_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_restart_mx025_prod
 Checking test 059 cpld_restart_mx025 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3070,8 +3070,8 @@ Checking test 059 cpld_restart_mx025 results ....
 Test 059 cpld_restart_mx025 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_control_c192_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_control_c192_prod
 Checking test 060 cpld_control_c192 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3122,8 +3122,8 @@ Checking test 060 cpld_control_c192 results ....
 Test 060 cpld_control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_control_c384_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_control_c384_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_control_c384_prod
 Checking test 061 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3177,8 +3177,8 @@ Checking test 061 cpld_control_c384 results ....
 Test 061 cpld_control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_controlfrac_c384_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_controlfrac_c384_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_controlfrac_c384_prod
 Checking test 062 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3232,8 +3232,8 @@ Checking test 062 cpld_controlfrac_c384 results ....
 Test 062 cpld_controlfrac_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_bmark_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_bmark_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_bmark_prod
 Checking test 063 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3287,8 +3287,8 @@ Checking test 063 cpld_bmark results ....
 Test 063 cpld_bmark PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_bmark_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_bmark_wave_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_bmark_wave_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_bmark_wave_prod
 Checking test 064 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3345,8 +3345,8 @@ Checking test 064 cpld_bmark_wave results ....
 Test 064 cpld_bmark_wave PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201106/cpld_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_194140/cpld_debug_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20201110/cpld_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_148154/cpld_debug_prod
 Checking test 065 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -3398,5 +3398,5 @@ Test 065 cpld_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Nov  7 16:36:14 UTC 2020
-Elapsed time: 03h:51m:27s. Have a nice day!
+Thu Nov 12 23:59:16 UTC 2020
+Elapsed time: 02h:34m:09s. Have a nice day!

--- a/tests/tests/fv3_ccpp_gocart_clm
+++ b/tests/tests/fv3_ccpp_gocart_clm
@@ -68,3 +68,8 @@ export CCPP_SUITE=FV3_GFS_2017_gfdlmp
 export CCPP_LIB_DIR=ccpp/lib
 export INPUT_NML=ccpp.gocart.nml.IN
 
+# Increase the number of nodes on Cheyenne to avoid out of memory errors
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  # Use 30 instead of 36 tasks per node
+  export TPN=30
+fi


### PR DESCRIPTION
## Description

Regression test logs for cheyenne.gnu, cheyenne.intel, orion.intel, wcoss_dell_p3 and wcoss_cray. Also included the update of  test `fv3_ccpp_gocart_clm` to use more nodes on Cheyenne for avoiding out-of-memory issues. This change has been tested on both cheyenne and orion.

Please wait with merging until early Friday morning (8am MT?) so that I can add the hera logs in case the system is functional again.

Update: hera.gnu is complete, just waiting for hera.intel